### PR TITLE
Add manual exchange rate setting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,11 @@
 # Google APIs
 VITE_GOOGLE_API_KEY=your_google_api_key_here
+VITE_GOOGLE_CLIENT_ID=your_google_client_id_here
 VITE_GOOGLE_SHEETS_ID=1T-nRJLZILYqu6Xubq74QjFrf5ep4mZWCp-UNdaLozZ0
 VITE_GOOGLE_DRIVE_FOLDER_ID=12ZY6kw2qBUQtXyz8qtcLuCYHCQKaZ3v6
 
-# Currency API
-VITE_EXCHANGE_RATE_API_KEY=your_exchange_rate_api_key_here
+
+# Currency conversion now uses una tasa manual configurada en la interfaz
 
 # Google Cloud Vision API (for OCR)
 VITE_GOOGLE_CLOUD_PROJECT_ID=your_project_id_here

--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-invoice3
+# Invoice Processor
+
+Aplicación React para subir facturas en PDF o imagen, extraer los datos principales y guardarlos en Google Sheets y Drive.
+
+## Instalación
+
+```bash
+npm install
+```
+
+Copia `.env.example` a `.env` y completa las credenciales de Google.
+
+## Uso
+
+```
+npm run dev
+```
+
+Abre la aplicación y conecta con Google. Desde la sección **Configuración de integración** podrás establecer manualmente el tipo de cambio USD → EUR. Cuando se procese una factura en dólares se aplicará este valor.
+

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { ProcessingCard } from './components/ProcessingCard';
 import { StatsCard } from './components/StatsCard';
 import { AuthButton } from './components/AuthButton';
 import { useInvoiceProcessor } from './hooks/useInvoiceProcessor';
+import { ExchangeRateInput } from './components/ExchangeRateInput';
 
 function App() {
   const { files, isProcessing, addFiles, clearAll, stats } = useInvoiceProcessor();
@@ -114,7 +115,7 @@ function App() {
         {/* Integration Info */}
         <div className="mt-12 bg-white rounded-xl border border-gray-200 p-6">
           <h3 className="text-lg font-semibold text-gray-900 mb-4">Configuración de integración</h3>
-          <div className="grid md:grid-cols-2 gap-6">
+          <div className="grid md:grid-cols-3 gap-6">
             <div>
               <h4 className="font-medium text-gray-800 mb-2">Google Sheets</h4>
               <p className="text-sm text-gray-600 mb-2">
@@ -134,7 +135,7 @@ function App() {
               <p className="text-sm text-gray-600 mb-2">
                 Los archivos se subirán automáticamente a:
               </p>
-              <a 
+              <a
                 href="https://drive.google.com/drive/u/2/folders/12ZY6kw2qBUQtXyz8qtcLuCYHCQKaZ3v6"
                 target="_blank"
                 rel="noopener noreferrer"
@@ -142,6 +143,13 @@ function App() {
               >
                 Ver carpeta de Drive →
               </a>
+            </div>
+            <div>
+              <h4 className="font-medium text-gray-800 mb-2">Tipo de cambio</h4>
+              <p className="text-sm text-gray-600 mb-2">
+                Define manualmente el cambio de USD a EUR:
+              </p>
+              <ExchangeRateInput />
             </div>
           </div>
         </div>
@@ -168,16 +176,8 @@ function App() {
 {`VITE_GOOGLE_API_KEY=tu_api_key_aqui
 VITE_GOOGLE_CLIENT_ID=tu_client_id_aqui
 VITE_GOOGLE_SHEETS_ID=1T-nRJLZILYqu6Xubq74QjFrf5ep4mZWCp-UNdaLozZ0
-VITE_GOOGLE_DRIVE_FOLDER_ID=12ZY6kw2qBUQtXyz8qtcLuCYHCQKaZ3v6
-VITE_EXCHANGE_RATE_API_KEY=tu_exchange_rate_api_key`}
+VITE_GOOGLE_DRIVE_FOLDER_ID=12ZY6kw2qBUQtXyz8qtcLuCYHCQKaZ3v6`}
               </pre>
-            </div>
-
-            <div>
-              <h4 className="font-medium text-gray-800 mb-2">3. API de conversión de moneda</h4>
-              <p className="text-sm text-gray-600">
-                Registrarse en <a href="https://exchangerate-api.com" className="text-blue-600 underline" target="_blank">ExchangeRate-API</a> para obtener una API key gratuita.
-              </p>
             </div>
           </div>
         </div>
@@ -198,9 +198,9 @@ VITE_EXCHANGE_RATE_API_KEY=tu_exchange_rate_api_key`}
             <div className="mx-auto w-12 h-12 bg-green-100 rounded-lg flex items-center justify-center mb-4">
               <TrendingUp className="text-green-600" size={24} />
             </div>
-            <h3 className="font-semibold text-gray-900 mb-2">Conversión de Moneda Real</h3>
+            <h3 className="font-semibold text-gray-900 mb-2">Conversión de Moneda Manual</h3>
             <p className="text-sm text-gray-600">
-              Conversión automática a euros con tipos de cambio actualizados en tiempo real
+              Define el tipo de cambio USD/EUR directamente en la interfaz
             </p>
           </div>
           

--- a/src/components/ExchangeRateInput.tsx
+++ b/src/components/ExchangeRateInput.tsx
@@ -1,0 +1,46 @@
+import React, { useState, useEffect } from 'react';
+import { CurrencyService } from '../services/currencyService';
+
+export const ExchangeRateInput: React.FC = () => {
+  const currencyService = CurrencyService.getInstance();
+  const [rate, setRate] = useState<string>('');
+
+  useEffect(() => {
+    const stored = currencyService.getManualRate('USD');
+    if (stored) {
+      setRate(stored.toString());
+    }
+  }, [currencyService]);
+
+  const handleSave = () => {
+    const numeric = parseFloat(rate.replace(',', '.'));
+    if (!isNaN(numeric) && numeric > 0) {
+      currencyService.setManualRate('USD', numeric);
+      alert('Tipo de cambio actualizado');
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      <label className="block text-sm font-medium text-gray-700">
+        Tipo de cambio USD a EUR (1 USD = ? EUR)
+      </label>
+      <div className="flex items-center space-x-2">
+        <input
+          type="number"
+          step="0.0001"
+          className="border rounded px-3 py-1 w-32"
+          value={rate}
+          onChange={(e) => setRate(e.target.value)}
+        />
+        <button
+          type="button"
+          onClick={handleSave}
+          className="px-3 py-1 bg-blue-600 text-white rounded"
+        >
+          Guardar
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/components/ProcessingCard.tsx
+++ b/src/components/ProcessingCard.tsx
@@ -10,7 +10,7 @@ export const ProcessingCard: React.FC<ProcessingCardProps> = ({ file }) => {
   const getStatusIcon = () => {
     switch (file.status.status) {
       case 'completed':
-        return <CheckCircle className="text-green-500\" size={20} />;
+        return <CheckCircle className="text-green-500" size={20} />;
       case 'error':
         return <AlertCircle className="text-red-500" size={20} />;
       default:

--- a/src/components/StatsCard.tsx
+++ b/src/components/StatsCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { DivideIcon as LucideIcon } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
 
 interface StatsCardProps {
   title: string;


### PR DESCRIPTION
## Summary
- add USD/EUR manual rate input component
- store user-defined rate in `CurrencyService`
- remove currency API references and update env example
- fix minor JSX issues
- document usage and manual rate option

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6845841960ec8329afa02d4d37240adf